### PR TITLE
feat(clips): add clips to the beam client

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build:ts:commonjs": "tsc --outDir dist/commonjs --module commonjs --target es6",
     "build": "rimraf dist && npm run build:ts:module && npm run build:ts:commonjs",
     "prepublish": "npm run build",
-    "lint": "tslint --project tsconfig.json \"src/**/*.ts\""
+    "lint": "tslint --project tsconfig.json \"src/**/*.ts\"",
+    "lint:fix": "tslint --project tsconfig.json --fix \"src/**/*.ts\""
   },
   "repository": {
     "type": "git",

--- a/src/defs/clipProperties.ts
+++ b/src/defs/clipProperties.ts
@@ -3,7 +3,7 @@ import { ILocator } from './locator';
 export enum Maturity {
     Family = 1,
     Teen = 2,
-    EighteenPlus = 3
+    EighteenPlus = 3,
 }
 
 export interface IClipProperties {
@@ -54,7 +54,7 @@ export interface IClipProperties {
 
     /**
      * Date time, in string format, at which this highlight completed upload
-    */
+     */
     uploadDate: string;
 
     /**

--- a/src/defs/clipProperties.ts
+++ b/src/defs/clipProperties.ts
@@ -1,0 +1,42 @@
+import { ILocator } from './locator';
+
+export interface IClipProperties {
+    //The content ID of this clip.
+    contentId: string;
+
+    //Locator information for this highlight (including the thumbnail and content)
+    contentLocators: ILocator[];
+
+    //Duration of this highlight in seconds
+    durationInSeconds: number;
+
+    //Date, in string format, this content will be deleted
+    expirationDate: string;
+
+    //Title of the highlight (default is the title of the live broadcast the highlight was created from)
+    title: string;
+
+    //Channel ID of the owner of this highlight
+    ownerChannelId: number;
+
+    //Mixer title id of source material (as opposed to xbox title id)
+    typeId: number;
+
+    //ID to get the clip and share with users
+    shareableId: string;
+
+    //Channel ID of the streamer this highlight was clipped from
+    streamerChannelId: number;
+
+    //Date time, in string format, at which this highlight completed upload
+    uploadDate: string;
+
+    //Number of views associated with this highlight
+    viewCount: number;
+
+    //Maturity of the clip (Family = 1, Teen = 2, EighteenPlus = 3)
+    contentMaturity: number;
+
+    //Tag for clips
+    tags: string[];
+}

--- a/src/defs/clipProperties.ts
+++ b/src/defs/clipProperties.ts
@@ -1,42 +1,74 @@
 import { ILocator } from './locator';
 
+export enum Maturity {
+    Family = 1,
+    Teen = 2,
+    EighteenPlus = 3
+}
+
 export interface IClipProperties {
-    //The content ID of this clip.
+    /**
+     * The content ID of this clip.
+     */
     contentId: string;
 
-    //Locator information for this highlight (including the thumbnail and content)
+    /**
+     * Locator information for this highlight (including the thumbnail and content)
+     */
     contentLocators: ILocator[];
 
-    //Duration of this highlight in seconds
+    /**
+     * Duration of this highlight in seconds
+     */
     durationInSeconds: number;
 
-    //Date, in string format, this content will be deleted
+    /**
+     * Date, in string format, this content will be deleted
+     */
     expirationDate: string;
 
-    //Title of the highlight (default is the title of the live broadcast the highlight was created from)
+    /**
+     * Title of the highlight (default is the title of the live broadcast the highlight was created from)
+     */
     title: string;
 
-    //Channel ID of the owner of this highlight
+    /**
+     * Channel ID of the owner of this highlight
+     */
     ownerChannelId: number;
 
-    //Mixer title id of source material (as opposed to xbox title id)
+    /**
+     * Mixer title id of source material (as opposed to xbox title id)
+     */
     typeId: number;
 
-    //ID to get the clip and share with users
+    /**
+     * ID to get the clip and share with users
+     */
     shareableId: string;
 
-    //Channel ID of the streamer this highlight was clipped from
+    /**
+     * Channel ID of the streamer this highlight was clipped from
+     */
     streamerChannelId: number;
 
-    //Date time, in string format, at which this highlight completed upload
+    /**
+     * Date time, in string format, at which this highlight completed upload
+    */
     uploadDate: string;
 
-    //Number of views associated with this highlight
+    /**
+     * Number of views associated with this highlight
+     */
     viewCount: number;
 
-    //Maturity of the clip (Family = 1, Teen = 2, EighteenPlus = 3)
-    contentMaturity: number;
+    /**
+     * Maturity of the clip
+     */
+    contentMaturity: Maturity;
 
-    //Tag for clips
+    /**
+     * Tag for clips
+     */
     tags: string[];
 }

--- a/src/defs/clipRequest.ts
+++ b/src/defs/clipRequest.ts
@@ -1,0 +1,10 @@
+export interface IClipRequest {
+    // Unique id for the broadcast
+    broadcastId: string;
+
+    //Title of the clip being looked for
+    highlightTitle: string;
+
+    //Length of the clip to create (default 30s, min 15s, max 300s)
+    clipDurationInSeconds: number;
+}

--- a/src/defs/clipRequest.ts
+++ b/src/defs/clipRequest.ts
@@ -1,10 +1,16 @@
 export interface IClipRequest {
-    // Unique id for the broadcast
+    /**
+     * Unique id for the broadcast
+     */
     broadcastId: string;
 
-    //Title of the clip being looked for
+    /**
+     * Title of the clip being looked for
+     */
     highlightTitle: string;
 
-    //Length of the clip to create (default 30s, min 15s, max 300s)
+    /**
+     * Length of the clip to create (default 30s, min 15s, max 300s)
+     */
     clipDurationInSeconds: number;
 }

--- a/src/defs/locator.ts
+++ b/src/defs/locator.ts
@@ -1,0 +1,7 @@
+export interface ILocator {
+    //Type of content source this is (e.g. Download, SmoothStreaming, Thumbnail etc.)
+    locatorType: string;
+
+    //URL for this content source
+    uri: string;
+}

--- a/src/defs/locator.ts
+++ b/src/defs/locator.ts
@@ -1,7 +1,11 @@
 export interface ILocator {
-    //Type of content source this is (e.g. Download, SmoothStreaming, Thumbnail etc.)
+    /**
+     * Type of content source this is (e.g. Download, SmoothStreaming, Thumbnail etc.)
+     */
     locatorType: string;
 
-    //URL for this content source
+    /**
+     * URL for this content source
+     */
     uri: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './providers/OAuth';
 export * from './providers/Provider';
 export * from './services/Channel';
 export * from './services/Chat';
+export * from './services/Clips';
 export * from './services/Game';
 export * from './services/Service';
 export * from './ws/Socket';

--- a/src/services/Clips.ts
+++ b/src/services/Clips.ts
@@ -1,0 +1,76 @@
+import { IClipProperties } from '../defs/clipProperties';
+import { IClipRequest } from '../defs/clipRequest';
+import { IResponse } from '../RequestRunner';
+import { Service } from './Service';
+
+/**
+ * Service for interacting with clips on the Mixer REST API.
+ */
+export class ClipsService extends Service {
+
+    /**
+     * Can a clip be created on the given broadcast.
+     */
+    public async canClip(broadcastId: string): Promise<boolean> {
+        try {
+            await this.makeHandled<boolean>('get', `clips/broadcasts/${broadcastId}/canClip`);
+        } catch {
+            return Promise.resolve(false);
+        }
+
+        return Promise.resolve(true);
+    }
+
+    /**
+     * Creates a clip.
+     */
+    public async createClip(p: IClipRequest): Promise<boolean> {
+        try {
+            await this.makeHandled<boolean>('post', `clips/create`, { body: p });
+        } catch {
+            return Promise.resolve(false);
+        }
+
+        return Promise.resolve(true);
+    }
+
+    /**
+     * Deletes a clip.
+     */
+    public async deleteClip(shareableId: string): Promise<boolean> {
+        try {
+            await this.makeHandled<boolean>('delete', `clips/delete/${shareableId}`);
+        } catch {
+            return Promise.resolve(false);
+        }
+
+        return Promise.resolve(true);
+    }
+
+    /**
+     * Gets a clip.
+     */
+    public getClip(shareableId: string): Promise<IResponse<IClipProperties>> {
+        return this.makeHandled<IClipProperties>('get', `clips/${shareableId}`);
+    }
+
+    /**
+     * Renames a clip.
+     */
+    public async renameClip(shareableId: string, newTitle: string): Promise<boolean> {
+        try {
+            await this.makeHandled<IClipProperties>('post', `clips/${shareableId}/metadata`, { body: { title: newTitle } });
+        } catch {
+            return Promise.resolve(false);
+        }
+
+        return Promise.resolve(true);
+    }
+
+    /**
+     * Returns all clips for the channel.
+     */
+    public getClips(channelId: string): Promise<IResponse<IClipProperties[]>> {
+        return this.makeHandled<IClipProperties[]>('get', `clips/channels/${channelId}`);
+    }
+}

--- a/src/services/Clips.ts
+++ b/src/services/Clips.ts
@@ -28,7 +28,7 @@ export class ClipsService extends Service {
 
     /**
      * Deletes a clip.
-     * 200: clip deleted
+     * 202: clip deleted
      * 400-500: cannot delete clip
      */
     public async deleteClip(shareableId: string): Promise<IResponse<void>> {

--- a/src/services/Clips.ts
+++ b/src/services/Clips.ts
@@ -9,42 +9,30 @@ import { Service } from './Service';
 export class ClipsService extends Service {
 
     /**
-     * Can a clip be created on the given broadcast.
+     * Can a clip be created on the given broadcast. Check the response code.
+     * 200: can clip
+     * 400-500: cannot clip
      */
-    public async canClip(broadcastId: string): Promise<boolean> {
-        try {
-            await this.makeHandled<boolean>('get', `clips/broadcasts/${broadcastId}/canClip`);
-        } catch {
-            return Promise.resolve(false);
-        }
-
-        return Promise.resolve(true);
+    public canClip(broadcastId: string): Promise<IResponse<void>> {
+        return this.makeHandled<void>('get', `clips/broadcasts/${broadcastId}/canClip`);
     }
 
     /**
      * Creates a clip.
+     * 200: clip created
+     * 400-500: cannot clip
      */
-    public async createClip(p: IClipRequest): Promise<boolean> {
-        try {
-            await this.makeHandled<boolean>('post', `clips/create`, { body: p });
-        } catch {
-            return Promise.resolve(false);
-        }
-
-        return Promise.resolve(true);
+    public async createClip(p: IClipRequest): Promise<IResponse<void>> {
+        return this.makeHandled<void>('post', `clips/create`, { body: p });
     }
 
     /**
      * Deletes a clip.
+     * 200: clip deleted
+     * 400-500: cannot delete clip
      */
-    public async deleteClip(shareableId: string): Promise<boolean> {
-        try {
-            await this.makeHandled<boolean>('delete', `clips/delete/${shareableId}`);
-        } catch {
-            return Promise.resolve(false);
-        }
-
-        return Promise.resolve(true);
+    public async deleteClip(shareableId: string): Promise<IResponse<void>> {
+        return this.makeHandled<void>('delete', `clips/delete/${shareableId}`);
     }
 
     /**
@@ -57,14 +45,8 @@ export class ClipsService extends Service {
     /**
      * Renames a clip.
      */
-    public async renameClip(shareableId: string, newTitle: string): Promise<boolean> {
-        try {
-            await this.makeHandled<IClipProperties>('post', `clips/${shareableId}/metadata`, { body: { title: newTitle } });
-        } catch {
-            return Promise.resolve(false);
-        }
-
-        return Promise.resolve(true);
+    public async renameClip(shareableId: string, newTitle: string): Promise<IResponse<IClipProperties>> {
+        return this.makeHandled<IClipProperties>('post', `clips/${shareableId}/metadata`, { body: { title: newTitle } });
     }
 
     /**


### PR DESCRIPTION
Add clipping to the beam client.

Please Look at:
A few of the endpoints do not return objects, just the fact that they return 200 is sufficient. For these enpoints I removed the IResponse portion and just had them return true or false. It looks kind of weird because it breaks the pattern. Thought? Also, if we want to go back to IResponse, what is the <T> for no body?