### PR TITLE
feat(services): defaulty instantiate an instance of each service

### DIFF
--- a/example/joinChat.js
+++ b/example/joinChat.js
@@ -18,7 +18,7 @@ client.use(new Mixer.OAuthProvider(client, {
 client.request('GET', 'users/current')
 .then(response => {
     userInfo = response.body;
-    return new Mixer.ChatService(client).join(response.body.channel.id);
+    return client.chat.join(response.body.channel.id);
 })
 .then(response => {
     const body = response.body;

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -11,6 +11,10 @@ import {
     IResponse,
 } from './RequestRunner';
 import { IGenericWebSocket, ISocketOptions, Socket } from './ws/Socket';
+import { ChatService } from './services/Chat';
+import { ClipsService } from './services/Clips';
+import { GameService } from './services/Game';
+import { ChannelService } from './services/Channel';
 
 // DO NOT EDIT, THIS IS UPDATE BY THE BUILD SCRIPT
 const packageVersion = '0.13.0'; // package version
@@ -25,6 +29,12 @@ export class Client {
         api: 'https://mixer.com/api/v1',
         public: 'https://mixer.com',
     };
+
+    public channel = new ChannelService(this);
+    public chat = new ChatService(this);
+    public clips = new ClipsService(this);
+    public game = new GameService(this);
+
     /**
      * The primary Mixer client, responsible for storing authentication state
      * and dispatching requests to the API.


### PR DESCRIPTION
While the service pattern has its merits, I fail to understand why it would be useful in such a small codebase. As shown by the change in our example it makes joining chat for a new user to the module about 1 million % more clearer.

Should this client grow larger we can always introduce a proper service management pattern later but right now A god class is fine in my books.

If you have alternative thoughts let me know.