### PR TITLE
fix: add support for catching uaccess

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -3,6 +3,7 @@ import { IncomingMessage } from 'http';
 // tslint:disable max-classes-per-file
 
 export const UNOTFOUND = 'UNOTFOUND';
+export const UACCESS = 'UACCESS';
 
 /**
  * Base error for all fe2 stuff.

--- a/src/ws/Socket.ts
+++ b/src/ws/Socket.ts
@@ -19,6 +19,7 @@ import {
     UnknownCodeError,
     UNOTFOUND,
 } from '../errors';
+import { UACCESS } from '../errors';
 import { Reply } from './Reply';
 
 // The method of the authentication packet to store.
@@ -481,6 +482,10 @@ export class Socket extends EventEmitter {
             if (e.message === UNOTFOUND) {
                 message =
                     'Authentication Failed: User not found. Please check our guide at: https://aka.ms/unotfound';
+            }
+            if (e.message === UACCESS) {
+                message =
+                    'Authentication Failed: Channel is in test mode. The client user does not have access during test mode.';
             }
             this.emit('error', new AuthenticationFailedError(message));
             this.close();


### PR DESCRIPTION
- This was causing a misleading error when debugging an application
- The error message could be tweaked. But this is also missing from the documentation on the dev site from the looks.