### PR TITLE
refactor: chat deprecation changes

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -27,8 +27,11 @@ const packageVersion = '0.13.0'; // package version
 export class Client {
     private provider: Provider;
     private userAgent: string;
-    public urls = {
-        api: 'https://mixer.com/api/v1',
+    public urls: { api: { [version: string]: string }, public: string } = {
+        api: {
+            v1: 'https://mixer.com/api/v1',
+            v2: 'https://mixer.com/api/v2',
+        },
         public: 'https://mixer.com',
     };
 
@@ -116,12 +119,17 @@ export class Client {
         method: string,
         path: string,
         data: IOptionalUrlRequestOptions = {},
+        apiVer: string = 'v1',
     ): Promise<IResponse<T>> {
+        let apiBase: string = this.urls.api[apiVer.toLowerCase()];
+        if (!apiBase) { // Default back to v1 if the one given is invalid.
+            apiBase = this.urls.api.v1;
+        }
         const req = all([
             this.provider ? this.provider.getRequest() : {},
             {
                 method: method || '',
-                url: this.buildAddress(this.urls.api, path || ''),
+                url: this.buildAddress(apiBase, path || ''),
                 headers: {
                     'User-Agent': this.userAgent,
                 },

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -64,9 +64,15 @@ export class Client {
 
     /**
      * Sets the the API/public URLs for the client.
+     *
+     * If you are changing the URL for the API, you can set the version to which to set with the URL given.
      */
-    public setUrl(kind: 'api' | 'public', url: string): this {
-        this.urls[kind] = url;
+    public setUrl(kind: 'api' | 'public', url: string, apiVer: 'v1' | 'v2' = 'v1'): this {
+        if (kind === 'api') {
+            this.urls.api[apiVer] = url;
+        } else {
+            this.urls[kind] = url;
+        }
         return this;
     }
 

--- a/src/services/Chat.ts
+++ b/src/services/Chat.ts
@@ -22,14 +22,14 @@ export class ChatService extends Service {
      * Joins the chat for a specified channel ID.
      */
     public join(channelId: number): Promise<IResponse<IChatJoinResponse>> {
-        return this.makeHandled<IChatJoinResponse>('get', `v2/chat/${channelId}`);
+        return this.makeHandled<IChatJoinResponse>('get', `v2/chats/${channelId}`);
     }
 
     /**
      * Retrieve a list of online users in a chat specified by channelId.
      */
     public getUsers(channelId: number, data: { page: number; limit: number }): Promise<IResponse<IUsersResponse[]>> {
-        return this.makeHandled<IUsersResponse[]>('get', `v2/chat/${channelId}/users`, {
+        return this.makeHandled<IUsersResponse[]>('get', `v2/chats/${channelId}/users`, {
             qs: data,
         });
     }
@@ -38,7 +38,7 @@ export class ChatService extends Service {
      * Search for users within a chat specified by channelId.
      */
     public searchUsers(channelId: number, data: { username: string; page: number; limit: number}): Promise<IResponse<IUsersResponse[]>> {
-        return this.makeHandled('get', `v2/chat/${channelId}/users/search`, {
+        return this.makeHandled('get', `v2/chats/${channelId}/users/search`, {
             qs: data,
         });
     }

--- a/src/services/Chat.ts
+++ b/src/services/Chat.ts
@@ -22,14 +22,14 @@ export class ChatService extends Service {
      * Joins the chat for a specified channel ID.
      */
     public join(channelId: number): Promise<IResponse<IChatJoinResponse>> {
-        return this.makeHandled<IChatJoinResponse>('get', `chats/${channelId}`);
+        return this.makeHandled<IChatJoinResponse>('get', `v2/chat/${channelId}`);
     }
 
     /**
      * Retrieve a list of online users in a chat specified by channelId.
      */
     public getUsers(channelId: number, data: { page: number; limit: number }): Promise<IResponse<IUsersResponse[]>> {
-        return this.makeHandled<IUsersResponse[]>('get', `chats/${channelId}/users`, {
+        return this.makeHandled<IUsersResponse[]>('get', `v2/chat/${channelId}/users`, {
             qs: data,
         });
     }
@@ -38,7 +38,7 @@ export class ChatService extends Service {
      * Search for users within a chat specified by channelId.
      */
     public searchUsers(channelId: number, data: { username: string; page: number; limit: number}): Promise<IResponse<IUsersResponse[]>> {
-        return this.makeHandled('get', `chats/${channelId}/users/search`, {
+        return this.makeHandled('get', `v2/chat/${channelId}/users/search`, {
             qs: data,
         });
     }

--- a/src/services/Service.ts
+++ b/src/services/Service.ts
@@ -6,6 +6,8 @@ export interface ICtor {
     new (msg: any): void;
 }
 
+const apiVerRegex = /^v[0-9]\//;
+
 /**
  * A service is basically a bridge/handler function for various endpoints.
  * It can be passed into the client and used magically.
@@ -42,7 +44,12 @@ export class Service {
         data?: IOptionalUrlRequestOptions,
         handlers?: { [key: string]: ICtor },
     ): Promise<IResponse<T>> {
-        return this.client.request(method, path, data)
+        let apiVersion: string;
+        if (apiVerRegex.test(path)) {
+            apiVersion = path.match(apiVerRegex)[0].slice(0, -1);
+            path = path.slice(3);
+        }
+        return this.client.request(method, path, data, apiVersion)
         .then(res => this.handleResponse(res, handlers));
     }
 }

--- a/src/ws/Socket.ts
+++ b/src/ws/Socket.ts
@@ -16,10 +16,10 @@ import {
     BadMessageError,
     NoMethodHandlerError,
     TimeoutError,
+    UACCESS,
     UnknownCodeError,
     UNOTFOUND,
 } from '../errors';
-import { UACCESS } from '../errors';
 import { Reply } from './Reply';
 
 // The method of the authentication packet to store.

--- a/src/ws/readme.md
+++ b/src/ws/readme.md
@@ -9,7 +9,7 @@ Your usage may look something like this:
 ```js
 // Require the socket
 const { Socket } = require('@mixer/client-node');
-// Some function that gets the JSON response from `GET /chats/:id`.
+// Some function that gets the JSON response from `GET /chat/:id`.
 const data = getDataFromChannelJoinEndpoint();
 
 const socket = new Socket(data.endpoints).boot();
@@ -37,7 +37,7 @@ A basic websocket client. It's an EventEmitter.
 
 ### new Socket(addresses)
 
-Construct a new socket client, using the list of addresses returned from the `GET /chats/:id` endpoint. Behind the scenes we load balance and do failover for you. How nice!
+Construct a new socket client, using the list of addresses returned from the `GET /chat/:id` endpoint. Behind the scenes we load balance and do failover for you. How nice!
 
 ### Socket.{IDLE|CONNECTED|CLOSED|ABORTED}
 
@@ -57,7 +57,7 @@ Return whether the socket is currently connected.
 
 ### socket.auth(channel[, user, authkey])
 
-Joins the chat of a certain channel by its ID. If you want to join anonymously (without being able to chat) you can omit the `user` and `authkey`. The `user` is the user ID you're authenticating as, the authkey is the alphanumeric token returns from `GET /api/v1/chats/:id`.
+Joins the chat of a certain channel by its ID. If you want to join anonymously (without being able to chat) you can omit the `user` and `authkey`. The `user` is the user ID you're authenticating as, the authkey is the alphanumeric token returns from `GET /api/v1/chat/:id`.
 
 ### socket.call(method, [args], [options])
 

--- a/src/ws/readme.md
+++ b/src/ws/readme.md
@@ -9,7 +9,7 @@ Your usage may look something like this:
 ```js
 // Require the socket
 const { Socket } = require('@mixer/client-node');
-// Some function that gets the JSON response from `GET /chat/:id`.
+// Some function that gets the JSON response from `GET /api/v2/chats/:id`.
 const data = getDataFromChannelJoinEndpoint();
 
 const socket = new Socket(data.endpoints).boot();
@@ -37,7 +37,7 @@ A basic websocket client. It's an EventEmitter.
 
 ### new Socket(addresses)
 
-Construct a new socket client, using the list of addresses returned from the `GET /chat/:id` endpoint. Behind the scenes we load balance and do failover for you. How nice!
+Construct a new socket client, using the list of addresses returned from the `GET /api/v2/chats/:id` endpoint. Behind the scenes we load balance and do failover for you. How nice!
 
 ### Socket.{IDLE|CONNECTED|CLOSED|ABORTED}
 
@@ -57,7 +57,7 @@ Return whether the socket is currently connected.
 
 ### socket.auth(channel[, user, authkey])
 
-Joins the chat of a certain channel by its ID. If you want to join anonymously (without being able to chat) you can omit the `user` and `authkey`. The `user` is the user ID you're authenticating as, the authkey is the alphanumeric token returns from `GET /api/v1/chat/:id`.
+Joins the chat of a certain channel by its ID. If you want to join anonymously (without being able to chat) you can omit the `user` and `authkey`. The `user` is the user ID you're authenticating as, the authkey is the alphanumeric token returns from `GET /api/v2/chats/:id`.
 
 ### socket.call(method, [args], [options])
 

--- a/test/unit/client.test.js
+++ b/test/unit/client.test.js
@@ -14,7 +14,11 @@ describe('client', function() {
 
     it('sets the url', function() {
         expect(this.client.setUrl('api', 'http://example.com'));
-        expect(this.client.urls.api).to.equal('http://example.com');
+        expect(this.client.urls.api.v1).to.equal('http://example.com');
+        expect(this.client.setUrl('api', 'http://example.net', 'v2'));
+        expect(this.client.urls.api.v2).to.equal('http://example.net');
+        expect(this.client.setUrl('public', 'http://example.io'));
+        expect(this.client.urls.public).to.equal('http://example.io');
     });
 
     it('makes a request successfully', function() {


### PR DESCRIPTION
All this is in relation to: https://github.com/mixer/developer-docs/pull/23

This allows the services to specify versions of the API to use. All be it they need to be set in the `urls` object which stills gives the user control over the URL's. However the `setUrl` method needs updating, but I wanted feedback on the current progress before looking into changing that method to support the deep object unless all of it was moved into the root to be like:

```javascript
const urls = {
  apiV1: 'foo',
  apiV2: 'bar',
  public: 'foobar'
};
```

But I didn't like the look of the keys but looks aren't always a need, lol.

I went with the Regex approach as performance wise it seems fine, along with allowing the services to support other versions (in the future already out of the box).

Documentation is still in progress to be updated on the `makeHandled` method to say about how you can set a different API version but this is the current work (which has all been tested)