### PR TITLE
fix(socket): err message checking

### DIFF
--- a/src/ws/Socket.ts
+++ b/src/ws/Socket.ts
@@ -481,11 +481,11 @@ export class Socket extends EventEmitter {
 
         promise.then(bang).catch((e: Error) => {
             let message = 'Authentication Failed, please check your credentials.';
-            if (e.message === UNOTFOUND) {
+            if (e === UNOTFOUND) {
                 message =
                     'Authentication Failed: User not found. Please check our guide at: https://aka.ms/unotfound';
             }
-            if (e.message === UACCESS) {
+            if (e === UACCESS) {
                 message =
                     'Authentication Failed: Channel is in test mode. The client user does not have access during test mode.';
             }

--- a/src/ws/Socket.ts
+++ b/src/ws/Socket.ts
@@ -481,7 +481,7 @@ export class Socket extends EventEmitter {
 
         promise.then(bang).catch((e: Error) => {
             let message = 'Authentication Failed, please check your credentials.';
-            if (typeof e != 'error') {
+            if (!(e instanceof Error)) {
                 if (e === UNOTFOUND) {
                     message =
                         'Authentication Failed: User not found. Please check our guide at: https://aka.ms/unotfound';

--- a/src/ws/Socket.ts
+++ b/src/ws/Socket.ts
@@ -481,13 +481,15 @@ export class Socket extends EventEmitter {
 
         promise.then(bang).catch((e: Error) => {
             let message = 'Authentication Failed, please check your credentials.';
-            if (e === UNOTFOUND) {
-                message =
-                    'Authentication Failed: User not found. Please check our guide at: https://aka.ms/unotfound';
-            }
-            if (e === UACCESS) {
-                message =
-                    'Authentication Failed: Channel is in test mode. The client user does not have access during test mode.';
+            if (typeof e != 'error') {
+                if (e === UNOTFOUND) {
+                    message =
+                        'Authentication Failed: User not found. Please check our guide at: https://aka.ms/unotfound';
+                }
+                if (e === UACCESS) {
+                    message =
+                        'Authentication Failed: Channel is in test mode. The client user does not have access during test mode.';
+                }
             }
             this.emit('error', new AuthenticationFailedError(message));
             this.close();


### PR DESCRIPTION
While debugging an application. I came over the `.message` property does not actually exist. The error code itself is the root `err` thus the _If_ statements are never actually working.

Not sure how this one was missed, or if something changed elsewhere.