### PR TITLE
fix: fix type information in ITokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1191,9 +1191,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ts-node": "^3.2.0",
     "tslint": "^5.5.0",
     "tslint-microsoft-contrib": "^5.0.1",
-    "typescript": "^2.4.1",
+    "typescript": "^3.4.5",
     "ws": "^1.0.1"
   },
   "dependencies": {

--- a/src/providers/OAuth.ts
+++ b/src/providers/OAuth.ts
@@ -9,8 +9,8 @@ export interface ITokenBase {
 }
 
 export interface ITokens extends ITokenBase {
-    // ISO Date
-    expires: string;
+    // ISO Date as string or Unix timestamp (in ms) or Date object
+    expires: number | string | Date;
 }
 
 export interface IParsedTokens extends ITokenBase {


### PR DESCRIPTION
Current type information doesn't match example from docs that is like this:
```typescript
client.use(new Mixer.OAuthProvider(client, {
    tokens: {
        access: 'Click here to get your Token!',
        expires: Date.now() + (365 * 24 * 60 * 60 * 1000)
    },
}));
```

Turns out, code indeed supports numbers and even Date object, so this PR corrects type information for TypeScript users.