### PR TITLE
Removed Broken getRequest and made ClientId? in IOAuthProviderOptions

### DIFF
--- a/src/providers/OAuth.ts
+++ b/src/providers/OAuth.ts
@@ -18,7 +18,7 @@ export interface IParsedTokens extends ITokenBase {
 }
 
 export interface IOAuthProviderOptions {
-    clientId: string;
+    clientId?: string;
     secret?: string;
     tokens?: ITokens;
 }
@@ -200,19 +200,19 @@ export class OAuthProvider extends Provider {
     /**
      * Returns info to add to the client's request.
      */
-    public getRequest() {
-        const headers: { [key: string]: string } = {
-            'Client-ID': this.details.client_id,
-        };
+    // public getRequest() {
+    //     const headers: { [key: string]: string } = {
+    //         'Client-ID': this.details.client_id,
+    //     };
 
-        if (this.isAuthenticated()) {
-            headers['Authorization'] = `Bearer ${this.tokens.access}`;
-        }
+    //     if (this.isAuthenticated()) {
+    //         headers['Authorization'] = `Bearer ${this.tokens.access}`;
+    //     }
 
-        return {
-            headers,
-        };
-    }
+    //     return {
+    //         headers,
+    //     };
+    // }
 
     public getClientId() {
         return this.details.client_id;


### PR DESCRIPTION
When using in a nodejs (TypeScript) app, the clientId is a required field and causes errors, the getRequest function is also causing issues when used in TypeScript and needs to be fixed.

Link to the logged Issue:
https://github.com/mixer/client-node/issues/109